### PR TITLE
Railsテキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,9 @@ gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.2', require: false
 
+gem 'redcarpet'
+gem 'coderay'
+
 gem "devise"
 gem 'activeadmin'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.1)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -250,6 +251,7 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.2)
   byebug
+  coderay
   devise
   devise-bootstrap-views
   devise-i18n
@@ -260,6 +262,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3)
   rails-i18n (~> 6.0)
+  redcarpet
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -79,3 +79,7 @@ h1 {
     font-size: 2rem;
     text-align: center;
 }
+
+a {
+    text-decoration: none !important;
+}

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -5,5 +5,9 @@ class TextsController < ApplicationController
     @texts = Text.where(genre: ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"])
   end
 
+  def show
+    @text = Text.find(params[:id])
+  end
+
   
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,49 @@
 module ApplicationHelper
+  require "redcarpet"
+  require "coderay"
+
+  class HTMLwithCoderay < Redcarpet::Render::HTML
+    def block_code(code, language)
+      language = language.split(':')[0] if language.present?
+        case language.to_s
+        when 'rb'
+            lang = :ruby
+        when 'yml'
+            lang = :yaml
+        when 'css'
+            lang = :css
+        when 'html'
+            lang = :html
+        when ''
+            lang = :md
+        else
+            lang = language
+        end
+        CodeRay.scan(code, lang).div
+    end
+  end
+
+  def markdown(text)
+    html_render = HTMLwithCoderay.new(
+      filter_html: true,
+      hard_wrap: true,
+      link_attributes: { rel: 'nofollow', target: "_blank" }
+    )
+    options = {
+        autolink: true,
+        space_after_headers: true,
+        no_intra_emphasis: true,
+        fenced_code_blocks: true,
+        tables: true,
+        hard_wrap: true,
+        xhtml: true,
+        lax_html_blocks: true,
+        strikethrough: true
+    }
+    markdown = Redcarpet::Markdown.new(html_render, options)
+    markdown.render(text).html_safe
+  end
+
   def max_width
     if devise_controller?
       'mw-md'
@@ -6,4 +51,6 @@ module ApplicationHelper
       'mw-xl'
     end
   end
+  
 end
+

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -10,22 +10,24 @@
     <div class="row">
       <% @texts.each do |text| %>
         <div class="col-12 col-md-6 col-lg-4 text-card-container">
-          <div class="card content-card border-dark mb-3">
-            <div class="card-header p-0">
-              <%= image_tag "default_image.jpg", class: "img-fluid" %>
-            </div>
-            <div class="card-body text-dark text-card-body">
-              <div>
-                  <object><a class="btn btn-secondary btn-block">読破済みにする</a></object>
+          <%= link_to text_path(text) do %>
+            <div class="card content-card border-dark mb-3">
+              <div class="card-header p-0">
+                <%= image_tag "default_image.jpg", class: "img-fluid" %>
               </div>
-              <p class="card-text text-title">
-                <%= text.title %>
-              </p>
-              <p>
-                【<%= text.genre %>】
-              </p>
+              <div class="card-body text-dark text-card-body">
+                <div>
+                  <object><a class="btn btn-secondary btn-block">読破済みにする</a></object>
+                </div>
+                <p class="card-text text-title">
+                  <%= text.title %>
+                </p>
+                <p>
+                  【<%= text.genre %>】
+                </p>
+              </div>
             </div>
-          </div>
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -2,4 +2,4 @@
   <%= @text.title %>
 </h1>
 
-<%= @text.content %>
+<%= markdown(@text.content) %>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,0 +1,5 @@
+<h1>
+  <%= @text.title %>
+</h1>
+
+<%= @text.content %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,5 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: "texts#index"
 
-  resources :texts 
+  resources :texts ,only: [:index, :show]
 end


### PR DESCRIPTION
## close #17

## 実装内容

- 一覧ページから詳細ページに移動できるように設定
- 詳細ページの実装
  - 「内容（content）」は Markdown に対応した表示ができるように設定
  - スタイルはデフォルトのまま
  - 「読破済み」機能は別タスクの為未実装

## 参考資料

- [やんばるCODE教材 RailsアプリへのMarkdownの導入](https://arcane-gorge-21903.herokuapp.com/texts/224)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

