### PR TITLE
Rails動画教材ページの実装

### DIFF
--- a/app/assets/stylesheets/card.scss
+++ b/app/assets/stylesheets/card.scss
@@ -14,6 +14,10 @@
     margin-top: 30px;
 }
 
+.movie-title {
+    margin-top: 10px;
+}
+
 .img-fluid {
     max-width: 100%;
     width: 100%;

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,0 +1,7 @@
+class MoviesController < ApplicationController
+    before_action :authenticate_user!
+
+    def index
+        @movies = Movie.where(genre: ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"])
+    end
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,6 +12,7 @@
         </a>
         <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
           <%= link_to "Ruby/Rails教材",texts_path, class: "dropdown-item" %>
+          <%= link_to "動画教材",movies_path, class: "dropdown-item" %>
           <%= link_to "AWS講座","#", class: "dropdown-item" %>
           <%= link_to "プログラミング勉強会","#", class: "dropdown-item" %>
           <%= link_to "質問集","#", class: "dropdown-item" %>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,0 +1,25 @@
+<div class="base-container mw-xl">
+  <div class="texts-wrapper mt-5">
+    <div class="row">
+      <% @movies.each.with_index(1) do |movie,i| %>
+        <div class="col-12 col-md-6 col-lg-4 movie-card-container">
+          <div class="card content-card border-dark mb-3">
+            <div class="card-header p-0">
+              <div class="embed-responsive embed-responsive-16by9">
+                <iframe width="560" height="315" src=<%= movie.url %> frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+              </div>
+            </div>
+            <div class="card-body text-dark text-card-body">
+              <div>
+                <object><a class="btn btn-secondary btn-block">視聴済みにする</a></object>
+              </div>
+              <p class="card-text movie-title">
+                Lv.<%= i %>：<%= movie.title %>
+              </p>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,6 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: "texts#index"
 
-  resources :texts ,only: [:index, :show]
+  resources :texts, only: [:index, :show]
+  resources :movies, only: [:index] 
 end


### PR DESCRIPTION
## close #18

## 実装内容

- Rails動画教材の一覧ページを作成
  - 視聴済み機能・ページネーションは別タスクの為未実装

- Rails動画教材では以下のジャンルを表示

```
["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]
```

- ナビバーの動画教材ページへのリンクが機能するように設定

## 参考資料

- [[公式]Bootstrap Cards](https://getbootstrap.jp/docs/4.5/components/card/)
- [[公式]Bootstrap Grid system](https://getbootstrap.jp/docs/4.5/layout/grid/)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

